### PR TITLE
Feature/initpush filter

### DIFF
--- a/momo_feed/CMakeLists.txt
+++ b/momo_feed/CMakeLists.txt
@@ -1,44 +1,32 @@
-add_library(feedhandler_config OBJECT
+add_executable(momo_feeder
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+
         ${CMAKE_CURRENT_SOURCE_DIR}/src/config/ConfigLoader.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/config/SubscriptionLoader.cpp
-)
 
-add_library(feedhandler_runtime OBJECT
         ${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/Dispatcher.cpp
-)
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/TopicRegistry.cpp
 
-add_library(feedhandler_sinks OBJECT
         ${CMAKE_CURRENT_SOURCE_DIR}/src/sinks/RedPandaSink.cpp
-)
 
-add_library(feedhandler_futu_core OBJECT
         ${CMAKE_CURRENT_SOURCE_DIR}/src/futu_quote/FutuQuoteSession.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/futu_quote/SubscriptionManager.cpp
 )
 
-foreach(t feedhandler_config feedhandler_runtime feedhandler_sinks feedhandler_futu_core)
-    target_include_directories(${t} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-    target_link_libraries(${t} PUBLIC momo_common)
-endforeach()
+target_include_directories(momo_feeder PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
-target_link_libraries(feedhandler_config PUBLIC yaml-cpp futu_openapi)
-target_link_libraries(feedhandler_sinks  PUBLIC PkgConfig::RDKAFKACPP PkgConfig::RDKAFKA)
-target_link_libraries(feedhandler_futu_core PUBLIC futu_openapi)
-
-add_executable(momo_feeder
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
-        $<TARGET_OBJECTS:feedhandler_config>
-        $<TARGET_OBJECTS:feedhandler_runtime>
-        $<TARGET_OBJECTS:feedhandler_sinks>
-        $<TARGET_OBJECTS:feedhandler_futu_core>
+target_link_libraries(momo_feeder PRIVATE
+        yaml-cpp
+        fmt
+        futu_openapi
+        PkgConfig::RDKAFKACPP
+        PkgConfig::RDKAFKA
 )
 
 target_compile_options(momo_feeder PRIVATE -fno-PIE)
 target_link_options(momo_feeder PRIVATE -no-pie)
-
-target_link_libraries(momo_feeder PRIVATE yaml-cpp fmt futu_openapi PkgConfig::RDKAFKACPP PkgConfig::RDKAFKA)
-
-target_include_directories(momo_feeder PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # install
 include(GNUInstallDirs)

--- a/momo_feed/config/apps.example.yaml
+++ b/momo_feed/config/apps.example.yaml
@@ -20,6 +20,10 @@ subscriptionmanager:
   capacity: 8192
   refresh_ms: 5000
   overflow: "block"
+  warmup:
+    window_ms: 1000
+    enable_threshold: 2
+    bypass_subtypes: [ KL1Min ]
 
 downstreams:
   - name: "redpanda-example"

--- a/momo_feed/config/apps.example.yaml
+++ b/momo_feed/config/apps.example.yaml
@@ -23,7 +23,7 @@ subscriptionmanager:
   warmup:
     window_ms: 1000
     enable_threshold: 2
-    bypass_subtypes: [ KL1Min ]
+    bypass_kinds: [ KL1Min ]
 
 downstreams:
   - name: "redpanda-example"

--- a/momo_feed/config/subscriptions.example.yaml
+++ b/momo_feed/config/subscriptions.example.yaml
@@ -5,7 +5,7 @@ defaults:
     - BasicQot
     - OrderBook
     - Ticker
-    - KL_1Min
+    - KL1Min
 
 securities:
   - symbol: HK.00700

--- a/momo_feed/include/common/Envelope.hpp
+++ b/momo_feed/include/common/Envelope.hpp
@@ -6,5 +6,5 @@ struct Envelope {
     std::string topic;      // futu.quote.raw
     std::string key;        // symbol
     std::string payload;    // bytes
-    std::int64_t ts_ns{0};  // ingest time
+    int64_t ingest_time_ms; // ingest time
 };

--- a/momo_feed/include/common/Envelope.hpp
+++ b/momo_feed/include/common/Envelope.hpp
@@ -1,10 +1,20 @@
 #pragma once
 #include <string>
 #include <cstdint>
+#include <vector>
+
+enum class MsgKind : uint16_t {
+    BasicQuote,
+    OrderBook,
+    Ticker,
+    KL1Min,
+    RT,
+    Broker
+};
 
 struct Envelope {
-    std::string topic;      // futu.quote.raw
-    std::string key;        // symbol
-    std::string payload;    // bytes
+    MsgKind kind;
+    std::string symbol; // key
+    std::vector<uint8_t> payload; // bytes
     int64_t ingest_time_ms; // ingest time
 };

--- a/momo_feed/include/common/Envelope.hpp
+++ b/momo_feed/include/common/Envelope.hpp
@@ -3,13 +3,14 @@
 #include <cstdint>
 #include <vector>
 
-enum class MsgKind : uint16_t {
-    BasicQuote,
-    OrderBook,
-    Ticker,
-    KL1Min,
-    RT,
-    Broker
+enum class MsgKind : int {
+    Unknown    = -1,
+    BasicQuote = 0,
+    OrderBook  = 1,
+    Ticker     = 2,
+    KL1Min     = 3,
+    RT         = 4,
+    Broker     = 5,
 };
 
 struct Envelope {

--- a/momo_feed/include/config/Config.hpp
+++ b/momo_feed/include/config/Config.hpp
@@ -23,7 +23,7 @@ struct SubscriptionCfg {
 struct WarmupCfg {
     int window_ms{1000};
     std::size_t enable_threshold{2};
-    std::vector<std::string> bypass_topics;
+    std::vector<int> bypass_kinds;
 };
 
 struct SubscriptionManagerCfg {

--- a/momo_feed/include/config/Config.hpp
+++ b/momo_feed/include/config/Config.hpp
@@ -6,6 +6,7 @@
 
 #include "LoggerConfig.hpp"
 #include "OverflowPolicy.hpp"
+#include "common/Envelope.hpp"
 
 namespace cfg {
 // ---------- session ----------
@@ -23,7 +24,7 @@ struct SubscriptionCfg {
 struct WarmupCfg {
     int window_ms{1000};
     std::size_t enable_threshold{2};
-    std::vector<int> bypass_kinds;
+    std::vector<MsgKind> bypass_kinds;
 };
 
 struct SubscriptionManagerCfg {

--- a/momo_feed/include/config/Config.hpp
+++ b/momo_feed/include/config/Config.hpp
@@ -19,11 +19,18 @@ struct SubscriptionCfg {
     std::string path;
 };
 
-// ---------- queue ----------
+// ---------- Manager ----------
+struct WarmupCfg {
+    int window_ms{1000};
+    std::size_t enable_threshold{2};
+    std::vector<std::string> bypass_topics;
+};
+
 struct SubscriptionManagerCfg {
     int refresh_ms{5000};
     std::size_t capacity{1024};
     cfg::OverflowPolicy overflow{cfg::OverflowPolicy::Block};
+    WarmupCfg warmup;
 };
 
 // ---------- sinks ----------

--- a/momo_feed/include/config/WarmupPolicy.hpp
+++ b/momo_feed/include/config/WarmupPolicy.hpp
@@ -4,19 +4,21 @@
 #include <unordered_set>
 #include <vector>
 
+#include "common/Envelope.hpp"
+
 namespace cfg {
 
     enum class WarmupMode { Bypass, Eligible };
 
     // Configuration-driven warmup policy.
-    // - Bypass: do not apply warmup gate for this topic.
-    // - Eligible: apply warmup gate for this topic.
+    // - Bypass: do not apply warmup gate for this kind.
+    // - Eligible: apply warmup gate for this kind.
     class WarmupPolicy {
     public:
         int window_ms{1000};
         std::size_t enable_threshold{2};
 
-        // Topics that should bypass warmup gate.
+        // Message kinds that should bypass warmup gate.
         std::unordered_set<int> bypass_kinds;
 
         WarmupPolicy() = default;

--- a/momo_feed/include/config/WarmupPolicy.hpp
+++ b/momo_feed/include/config/WarmupPolicy.hpp
@@ -18,14 +18,15 @@ namespace cfg {
         int window_ms{1000};
         std::size_t enable_threshold{2};
 
-        // Message kinds that should bypass warmup gate.
-        std::unordered_set<int> bypass_kinds;
+        struct MsgKindHash {
+            std::size_t operator()(MsgKind k) const noexcept {
+                return static_cast<std::size_t>(static_cast<int>(k));
+            }
+        };
+        std::unordered_set<MsgKind, MsgKindHash> bypass_kinds;
 
-        WarmupPolicy() = default;
-
-        WarmupMode mode(MsgKind k) const {
-            return bypass_kinds.count(static_cast<int>(k)) ? WarmupMode::Bypass
-                                                           : WarmupMode::Eligible;
+        WarmupMode mode(MsgKind k) const noexcept {
+            return bypass_kinds.contains(k) ? WarmupMode::Bypass : WarmupMode::Eligible;
         }
     };
 

--- a/momo_feed/include/config/WarmupPolicy.hpp
+++ b/momo_feed/include/config/WarmupPolicy.hpp
@@ -17,16 +17,13 @@ namespace cfg {
         std::size_t enable_threshold{2};
 
         // Topics that should bypass warmup gate.
-        std::unordered_set<std::string> bypass_topics;
+        std::unordered_set<int> bypass_kinds;
 
         WarmupPolicy() = default;
 
-        WarmupMode mode(std::string_view topic) const noexcept {
-            // Note: topic strings are small; unordered_set lookup is fine.
-            if (bypass_topics.find(std::string(topic)) != bypass_topics.end()) {
-                return WarmupMode::Bypass;
-            }
-            return WarmupMode::Eligible;
+        WarmupMode mode(MsgKind k) const {
+            return bypass_kinds.count(static_cast<int>(k)) ? WarmupMode::Bypass
+                                                           : WarmupMode::Eligible;
         }
     };
 

--- a/momo_feed/include/config/WarmupPolicy.hpp
+++ b/momo_feed/include/config/WarmupPolicy.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace cfg {
+
+    enum class WarmupMode { Bypass, Eligible };
+
+    // Configuration-driven warmup policy.
+    // - Bypass: do not apply warmup gate for this topic.
+    // - Eligible: apply warmup gate for this topic.
+    class WarmupPolicy {
+    public:
+        int window_ms{1000};
+        std::size_t enable_threshold{2};
+
+        // Topics that should bypass warmup gate.
+        std::unordered_set<std::string> bypass_topics;
+
+        WarmupPolicy() = default;
+
+        WarmupMode mode(std::string_view topic) const noexcept {
+            // Note: topic strings are small; unordered_set lookup is fine.
+            if (bypass_topics.find(std::string(topic)) != bypass_topics.end()) {
+                return WarmupMode::Bypass;
+            }
+            return WarmupMode::Eligible;
+        }
+    };
+
+} // namespace cfg

--- a/momo_feed/include/futu_quote/SubscriptionManager.hpp
+++ b/momo_feed/include/futu_quote/SubscriptionManager.hpp
@@ -16,6 +16,7 @@
 #include "sinks/Sink.hpp"
 
 using SubscriptionLoadFn = std::function<std::expected<SubscribeConfig, std::string>(const std::string&)>;
+using SteadyTP = std::chrono::steady_clock::time_point;
 
 class SubscriptionManager {
   public:
@@ -24,6 +25,31 @@ class SubscriptionManager {
         std::chrono::milliseconds refresh_interval{5000};
         std::size_t capacity{32768};
         queue::OverflowPolicy overflow{queue::OverflowPolicy::Block};
+    };
+
+    // -----------------------------------------------------------------------------
+    // Warmup gate (restart-safe-by-behavior, no persistent state)
+    //
+    // Problem we address:
+    // - After (re)subscribe, OpenD often immediately pushes a snapshot which is
+    //   frequently the "last" cached value (duplicate) even outside trading hours.
+    // - We don't want that single snapshot to look like "new data" during deploy.
+    //
+    // Strategy (per topic+key):
+    // - After we (re)apply subscriptions, open a short warmup window (default 1s).
+    // - During warmup, buffer all messages instead of forwarding.
+    // - When window ends:
+    //     * if buffered count == 1: DROP it (snapshot-only, typical deploy/restart)
+    //     * if buffered count >= 2: FORWARD ALL buffered messages (no data loss)
+    // - After warmup ends, forward messages normally.
+    //
+    // This is intentionally lightweight: no protobuf decode, no heavy hashing,
+    // no RocksDB, no extra processes.
+    // -----------------------------------------------------------------------------
+    struct WarmupSlot {
+        SteadyTP until{};
+        bool active{false};
+        std::vector<Envelope> buf; // keep all during warmup to avoid data loss
     };
 
     SubscriptionManager(Sink sink,
@@ -63,7 +89,7 @@ private:
     Futu::u32_t subscribe_api(const SecurityId& id, const std::vector<Qot_Common::SubType>& subs);
     Futu::u32_t unsubscribe_api(const SecurityId& id, const std::vector<Qot_Common::SubType>& subs);
 
-    static int64_t now_ns();
+    static int64_t now_ms();
     bool enqueue(Envelope&& e);
 
 private:

--- a/momo_feed/include/futu_quote/SubscriptionManager.hpp
+++ b/momo_feed/include/futu_quote/SubscriptionManager.hpp
@@ -13,6 +13,7 @@
 #include "Subscription.hpp"
 #include "common/Envelope.hpp"
 #include "common/SPSCQueue.hpp"
+#include "config/WarmupPolicy.hpp"
 #include "sinks/Sink.hpp"
 
 using SubscriptionLoadFn = std::function<std::expected<SubscribeConfig, std::string>(const std::string&)>;
@@ -25,6 +26,7 @@ class SubscriptionManager {
         std::chrono::milliseconds refresh_interval{5000};
         std::size_t capacity{32768};
         queue::OverflowPolicy overflow{queue::OverflowPolicy::Block};
+        cfg::WarmupPolicy warmup; // config-driven warmup policy
     };
 
     // -----------------------------------------------------------------------------

--- a/momo_feed/include/runtime/TopicRegistry.hpp
+++ b/momo_feed/include/runtime/TopicRegistry.hpp
@@ -10,6 +10,6 @@ namespace runtime {
     std::string_view topic_for_msgkind(MsgKind kind) noexcept;
     std::string_view topic_for_subtype(Qot_Common::SubType st) noexcept;
 
-    MsgKind msgkind_for_topic(std::string_view tp) noexcept;
+    MsgKind msgkind_for_yamlcfg(std::string_view tp) noexcept;
     MsgKind msgkind_for_subtype(Qot_Common::SubType st) noexcept;
 } // namespace runtime

--- a/momo_feed/include/runtime/TopicRegistry.hpp
+++ b/momo_feed/include/runtime/TopicRegistry.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <string_view>
+
+#include "common/Envelope.hpp"
+#include "Proto/Qot_Common.pb.h"
+
+// Central place to map SubType <-> topic names produced by feedhandler.
+// Keep topic naming stable and avoid scattering hard-coded strings across modules.
+namespace runtime {
+    std::string_view topic_for_msgkind(MsgKind kind) noexcept;
+
+    std::string_view topic_for_subtype(Qot_Common::SubType st) noexcept;
+
+} // namespace runtime

--- a/momo_feed/include/runtime/TopicRegistry.hpp
+++ b/momo_feed/include/runtime/TopicRegistry.hpp
@@ -8,7 +8,8 @@
 // Keep topic naming stable and avoid scattering hard-coded strings across modules.
 namespace runtime {
     std::string_view topic_for_msgkind(MsgKind kind) noexcept;
-
     std::string_view topic_for_subtype(Qot_Common::SubType st) noexcept;
 
+    MsgKind msgkind_for_topic(std::string_view tp) noexcept;
+    MsgKind msgkind_for_subtype(Qot_Common::SubType st) noexcept;
 } // namespace runtime

--- a/momo_feed/include/sinks/DemoLogSink.hpp
+++ b/momo_feed/include/sinks/DemoLogSink.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "runtime/Dispatcher.hpp"
 #include "common/JsonLogger.hpp"
+#include "runtime/TopicRegistry.hpp"
 
 class DemoLogSink final : public ISink {
 public:
@@ -9,8 +10,8 @@ public:
     void submit(std::shared_ptr<const Envelope> e) override {
         logger::info("sink", "enqueue",
                      {logger::field("name", name_),
-                      logger::field("topic", e->topic),
-                      logger::field("key", e->key),
+                      logger::field("topic", runtime::topic_for_msgkind(e->kind)),
+                      logger::field("key", e->symbol),
                       logger::num("size", e->payload.size()),
                       logger::num("ingest_time_ns", e->ingest_time_ms)});
     }

--- a/momo_feed/include/sinks/DemoLogSink.hpp
+++ b/momo_feed/include/sinks/DemoLogSink.hpp
@@ -12,7 +12,7 @@ public:
                       logger::field("topic", e->topic),
                       logger::field("key", e->key),
                       logger::num("size", e->payload.size()),
-                      logger::num("ts_ns", e->ts_ns)});
+                      logger::num("ingest_time_ns", e->ingest_time_ms)});
     }
     void flush(int timeout_ms) override
     {}

--- a/momo_feed/src/config/ConfigLoader.cpp
+++ b/momo_feed/src/config/ConfigLoader.cpp
@@ -39,6 +39,31 @@ static std::expected<T, cfg::ConfigError> optional_scalar_as(
     }
 }
 
+template <typename T>
+static std::expected<std::vector<T>, cfg::ConfigError> optional_seq_as(
+    const YAML::Node& n,
+    const std::string& file,
+    const std::string& path) {
+    std::vector<T> out;
+    if (!n) return out;
+    if (!n.IsSequence()) {
+        return std::unexpected(cfg::ConfigError{file, path, "expected sequence"});
+    }
+    out.reserve(n.size());
+    for (std::size_t i = 0; i < n.size(); ++i) {
+        const auto item = n[i];
+        if (!item.IsScalar()) {
+            return std::unexpected(cfg::ConfigError{file, path + "[" + std::to_string(i) + "]", "expected scalar"});
+        }
+        try {
+            out.push_back(item.as<T>());
+        } catch (const std::exception& ex) {
+            return std::unexpected(cfg::ConfigError{file, path + "[" + std::to_string(i) + "]", ex.what()});
+        }
+    }
+    return out;
+}
+
 static std::expected<cfg::OverflowPolicy, cfg::ConfigError> parse_overflow_policy(
     std::string_view value,
     const std::string& file,
@@ -171,6 +196,34 @@ cfg::ConfigLoader::load(const std::string& path) {
         auto overflow = parse_overflow_policy(*overflow_value, path, "subscriptionmanager.overflow");
         if (!overflow) return std::unexpected(overflow.error());
         cfg.submanager.overflow = *overflow;
+
+// -------- warmup gate --------
+if (auto wn = n["warmup"]; wn) {
+    if (!wn.IsMap()) {
+        return std::unexpected(ConfigError{path, "subscriptionmanager.warmup", "expected map"});
+    }
+
+    auto window_ms = optional_scalar_as<int>(
+        wn["window_ms"], path, "subscriptionmanager.warmup.window_ms", cfg.submanager.warmup.window_ms);
+    if (!window_ms) return std::unexpected(window_ms.error());
+    if (*window_ms < 0) {
+        return std::unexpected(ConfigError{path, "subscriptionmanager.warmup.window_ms", "must be >= 0"});
+    }
+    cfg.submanager.warmup.window_ms = *window_ms;
+
+    auto enable_th = optional_scalar_as<std::size_t>(
+        wn["enable_threshold"], path, "subscriptionmanager.warmup.enable_threshold", cfg.submanager.warmup.enable_threshold);
+    if (!enable_th) return std::unexpected(enable_th.error());
+    if (*enable_th == 0) {
+        return std::unexpected(ConfigError{path, "subscriptionmanager.warmup.enable_threshold", "must be >= 1"});
+    }
+    cfg.submanager.warmup.enable_threshold = *enable_th;
+
+    auto bypass = optional_seq_as<std::string>(
+        wn["bypass_topics"], path, "subscriptionmanager.warmup.bypass_topics");
+    if (!bypass) return std::unexpected(bypass.error());
+    cfg.submanager.warmup.bypass_topics = std::move(*bypass);
+}
     }
 
     // -------- downstreams --------

--- a/momo_feed/src/config/ConfigLoader.cpp
+++ b/momo_feed/src/config/ConfigLoader.cpp
@@ -3,6 +3,8 @@
 #include <yaml-cpp/yaml.h>
 #include <filesystem>
 
+#include "runtime/TopicRegistry.hpp"
+
 namespace fs = std::filesystem;
 
 template <typename T>
@@ -197,33 +199,48 @@ cfg::ConfigLoader::load(const std::string& path) {
         if (!overflow) return std::unexpected(overflow.error());
         cfg.submanager.overflow = *overflow;
 
-// -------- warmup gate --------
-if (auto wn = n["warmup"]; wn) {
-    if (!wn.IsMap()) {
-        return std::unexpected(ConfigError{path, "subscriptionmanager.warmup", "expected map"});
-    }
+        // -------- warmup gate --------
+        if (auto wn = n["warmup"]; wn) {
+            if (!wn.IsMap()) {
+                return std::unexpected(ConfigError{path, "subscriptionmanager.warmup", "expected map"});
+            }
 
-    auto window_ms = optional_scalar_as<int>(
-        wn["window_ms"], path, "subscriptionmanager.warmup.window_ms", cfg.submanager.warmup.window_ms);
-    if (!window_ms) return std::unexpected(window_ms.error());
-    if (*window_ms < 0) {
-        return std::unexpected(ConfigError{path, "subscriptionmanager.warmup.window_ms", "must be >= 0"});
-    }
-    cfg.submanager.warmup.window_ms = *window_ms;
+            auto window_ms = optional_scalar_as<int>(
+                wn["window_ms"], path, "subscriptionmanager.warmup.window_ms", cfg.submanager.warmup.window_ms);
+            if (!window_ms) return std::unexpected(window_ms.error());
+            if (*window_ms < 0) {
+                return std::unexpected(ConfigError{path, "subscriptionmanager.warmup.window_ms", "must be >= 0"});
+            }
+            cfg.submanager.warmup.window_ms = *window_ms;
 
-    auto enable_th = optional_scalar_as<std::size_t>(
-        wn["enable_threshold"], path, "subscriptionmanager.warmup.enable_threshold", cfg.submanager.warmup.enable_threshold);
-    if (!enable_th) return std::unexpected(enable_th.error());
-    if (*enable_th == 0) {
-        return std::unexpected(ConfigError{path, "subscriptionmanager.warmup.enable_threshold", "must be >= 1"});
-    }
-    cfg.submanager.warmup.enable_threshold = *enable_th;
+            auto enable_th = optional_scalar_as<std::size_t>(
+                wn["enable_threshold"], path, "subscriptionmanager.warmup.enable_threshold", cfg.submanager.warmup.enable_threshold);
+            if (!enable_th) return std::unexpected(enable_th.error());
+            if (*enable_th == 0) {
+                return std::unexpected(ConfigError{path, "subscriptionmanager.warmup.enable_threshold", "must be >= 1"});
+            }
+            cfg.submanager.warmup.enable_threshold = *enable_th;
 
-    auto bypass = optional_seq_as<std::string>(
-        wn["bypass_topics"], path, "subscriptionmanager.warmup.bypass_topics");
-    if (!bypass) return std::unexpected(bypass.error());
-    cfg.submanager.warmup.bypass_topics = std::move(*bypass);
-}
+            auto bypass = optional_seq_as<std::string>(
+                wn["bypass_subtypes"], path, "subscriptionmanager.warmup.bypass_subtypes");
+            if (!bypass) return std::unexpected(bypass.error());
+
+            if (bypass->empty()) {
+                auto bypass_legacy = optional_seq_as<std::string>(
+                    wn["bypass_topics"], path, "subscriptionmanager.warmup.bypass_topics");
+                if (!bypass_legacy) return std::unexpected(bypass_legacy.error());
+                bypass = std::move(*bypass_legacy);
+            }
+
+            cfg.submanager.warmup.bypass_kinds.clear();
+            cfg.submanager.warmup.bypass_kinds.reserve(bypass->size());
+            for (std::size_t i = 0; i < bypass->size(); ++i) {
+                const auto& token = (*bypass)[i];
+                auto kind = runtime::msgkind_for_topic(token);
+                cfg.submanager.warmup.bypass_kinds.push_back(static_cast<int>(kind));
+            }
+
+        }
     }
 
     // -------- downstreams --------

--- a/momo_feed/src/config/ConfigLoader.cpp
+++ b/momo_feed/src/config/ConfigLoader.cpp
@@ -221,23 +221,15 @@ cfg::ConfigLoader::load(const std::string& path) {
             }
             cfg.submanager.warmup.enable_threshold = *enable_th;
 
-            auto bypass = optional_seq_as<std::string>(
-                wn["bypass_subtypes"], path, "subscriptionmanager.warmup.bypass_subtypes");
-            if (!bypass) return std::unexpected(bypass.error());
-
-            if (bypass->empty()) {
-                auto bypass_legacy = optional_seq_as<std::string>(
-                    wn["bypass_topics"], path, "subscriptionmanager.warmup.bypass_topics");
-                if (!bypass_legacy) return std::unexpected(bypass_legacy.error());
-                bypass = std::move(*bypass_legacy);
-            }
-
+            auto bypass_kinds = optional_seq_as<std::string>(
+                wn["bypass_kinds"], path, "subscriptionmanager.warmup.bypass_kinds");
+            if (!bypass_kinds) return std::unexpected(bypass_kinds.error());
             cfg.submanager.warmup.bypass_kinds.clear();
-            cfg.submanager.warmup.bypass_kinds.reserve(bypass->size());
-            for (std::size_t i = 0; i < bypass->size(); ++i) {
-                const auto& token = (*bypass)[i];
-                auto kind = runtime::msgkind_for_topic(token);
-                cfg.submanager.warmup.bypass_kinds.push_back(static_cast<int>(kind));
+            cfg.submanager.warmup.bypass_kinds.reserve(bypass_kinds->size());
+            for (std::size_t i = 0; i < bypass_kinds->size(); ++i) {
+                const auto& token = (*bypass_kinds)[i];
+                auto kind = runtime::msgkind_for_yamlcfg(token);
+                cfg.submanager.warmup.bypass_kinds.push_back(kind);
             }
 
         }

--- a/momo_feed/src/config/SubscriptionLoader.cpp
+++ b/momo_feed/src/config/SubscriptionLoader.cpp
@@ -102,7 +102,7 @@ std::expected<void, std::string> cfg::SubscriptionLoader::parse_subtype(const st
     if (s == "BasicQot") { out = Qot_Common::SubType_Basic; return {}; }
     if (s == "OrderBook" ) { out = Qot_Common::SubType_OrderBook; return {}; }
     if (s == "Ticker") { out = Qot_Common::SubType_Ticker; return {}; }
-    if (s == "KL_1Min") { out = Qot_Common::SubType_KL_1Min; return {}; }
+    if (s == "KL1Min") { out = Qot_Common::SubType_KL_1Min; return {}; }
     if (s == "RT") { out = Qot_Common::SubType_RT; return {}; }
     if (s == "Broker") { out = Qot_Common::SubType_Broker; return {}; }
     return std::unexpected("unknown subtype: " + s);

--- a/momo_feed/src/futu_quote/FutuQuoteSession.cpp
+++ b/momo_feed/src/futu_quote/FutuQuoteSession.cpp
@@ -76,6 +76,18 @@ void FutuQuoteSession::OnInitConnect(Futu::FTAPI_Conn *pConn,
     connected_.store(nErrCode == 0);
     if (nErrCode != 0) {
         next_reconnect_at_ns_.store(steady_now_ns(), std::memory_order_release);
+        logger::warn("session", "init_connect_failed",
+                     {logger::num("err", nErrCode),
+                      logger::field("desc", strDesc ? strDesc : ""),
+                      logger::field("ip", ip_),
+                      logger::num("port", port_),
+                      logger::num("reconnect_interval_ms", reconnect_interval_.count())});
+    } else {
+        logger::info("session", "init_connect_ok",
+                     {logger::num("err", nErrCode),
+                      logger::field("desc", strDesc ? strDesc : ""),
+                      logger::field("ip", ip_),
+                      logger::num("port", port_)});
     }
     if (cbs_.on_connected) {
         cbs_.on_connected(cbs_.ctx, nErrCode, strDesc);
@@ -86,6 +98,11 @@ void FutuQuoteSession::OnDisConnect(Futu::FTAPI_Conn *pConn,
                                     Futu::i64_t nErrCode) {
     connected_.store(false);
     next_reconnect_at_ns_.store(steady_now_ns(), std::memory_order_release);
+    logger::warn("session", "disconnected",
+                 {logger::num("err", nErrCode),
+                  logger::field("ip", ip_),
+                  logger::num("port", port_),
+                  logger::num("reconnect_interval_ms", reconnect_interval_.count())});
     if (cbs_.on_disconnected) {
         cbs_.on_disconnected(cbs_.ctx, nErrCode);
     }

--- a/momo_feed/src/futu_quote/SubscriptionManager.cpp
+++ b/momo_feed/src/futu_quote/SubscriptionManager.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "common/JsonLogger.hpp"
+#include "runtime/TopicRegistry.hpp"
 
 static std::size_t next_pow2(std::size_t v) {
     if (v < 2) return 2;
@@ -98,8 +99,8 @@ void SubscriptionManager::on_push_basicqot(const Qot_UpdateBasicQot::Response &s
         single_rsp.mutable_s2c()->add_basicqotlist()->CopyFrom(item);
 
         Envelope e;
-        e.topic = "futu.basicqot.pb";
-        e.key = make_key(sec.market(), sec.code());
+        e.kind = MsgKind::BasicQuote;
+        e.symbol = make_key(sec.market(), sec.code());
         e.ingest_time_ms = now_ms();
         e.payload.resize(static_cast<size_t>(single_rsp.ByteSizeLong()));
         if (!single_rsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
@@ -111,9 +112,9 @@ void SubscriptionManager::on_push_basicqot(const Qot_UpdateBasicQot::Response &s
 void SubscriptionManager::on_push_orderbook(const Qot_UpdateOrderBook::Response &stRsp)
 {
     Envelope e;
-    e.topic = "futu.orderbook.pb";
+    e.kind = MsgKind::OrderBook;
     const auto& sec = stRsp.s2c().security();
-    e.key = make_key(sec.market(), sec.code());
+    e.symbol = make_key(sec.market(), sec.code());
     e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
@@ -125,9 +126,9 @@ void SubscriptionManager::on_push_orderbook(const Qot_UpdateOrderBook::Response 
 void SubscriptionManager::on_push_ticker(const Qot_UpdateTicker::Response &stRsp)
 {
     Envelope e;
-    e.topic = "futu.ticker.pb";
+    e.kind = MsgKind::Ticker;
     const auto& sec = stRsp.s2c().security();
-    e.key = make_key(sec.market(), sec.code());
+    e.symbol = make_key(sec.market(), sec.code());
     e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
@@ -139,9 +140,9 @@ void SubscriptionManager::on_push_ticker(const Qot_UpdateTicker::Response &stRsp
 void SubscriptionManager::on_push_kl(const Qot_UpdateKL::Response &stRsp)
 {
     Envelope e;
-    e.topic = "futu.kl1min.pb";
+    e.kind = MsgKind::KL1Min;
     const auto& sec = stRsp.s2c().security();
-    e.key = make_key(sec.market(), sec.code());
+    e.symbol = make_key(sec.market(), sec.code());
     e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
@@ -153,9 +154,9 @@ void SubscriptionManager::on_push_kl(const Qot_UpdateKL::Response &stRsp)
 void SubscriptionManager::on_push_rt(const Qot_UpdateRT::Response &stRsp)
 {
     Envelope e;
-    e.topic = "futu.rt.pb";
+    e.kind = MsgKind::RT;
     const auto& sec = stRsp.s2c().security();
-    e.key = make_key(sec.market(), sec.code());
+    e.symbol = make_key(sec.market(), sec.code());
     e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
@@ -167,9 +168,9 @@ void SubscriptionManager::on_push_rt(const Qot_UpdateRT::Response &stRsp)
 void SubscriptionManager::on_push_broker(const Qot_UpdateBroker::Response &stRsp)
 {
     Envelope e;
-    e.topic = "futu.broker.pb";
+    e.kind = MsgKind::Broker;
     const auto& sec = stRsp.s2c().security();
-    e.key = make_key(sec.market(), sec.code());
+    e.symbol = make_key(sec.market(), sec.code());
     e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
@@ -185,27 +186,43 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
 
     // Per (topic|key) warmup slots.
     std::unordered_map<std::string, WarmupSlot> warmups;
-    constexpr auto WARMUP = std::chrono::milliseconds(1000);
 
-    auto open_warmup_all_topics = [&](const std::string& key) {
+    // Topic-level enable: once we observe any (topic,security) producing >= enable_threshold
+    // messages during warmup, we consider this topic "active" and will flush even single buffered
+    // messages for all securities of this topic (avoid false drops for low-rate symbols).
+    std::unordered_map<std::string, bool> topic_enabled;
+    const auto WARMUP = std::chrono::milliseconds(opts_.warmup.window_ms);
+
+    auto warmup_mode = [&](std::string_view topic) -> cfg::WarmupMode {
+        return opts_.warmup.mode(topic);
+    };
+
+    auto open_warmup_for_mask = [&](const std::string& key, SubMask mask) {
+        if (WARMUP.count() == 0) return; // disabled
         const auto until = std::chrono::steady_clock::now() + WARMUP;
-        // We open warmup for all topics we produce.
-        static constexpr const char* TOPICS[] = {
-            "futu.basicqot.pb",
-            "futu.orderbook.pb",
-            "futu.ticker.pb",
-            "futu.kl1min.pb",
-            "futu.rt.pb",
-            "futu.broker.pb",
-        };
-        for (auto* t : TOPICS) {
-            auto& slot = warmups[warm_key(t, key)];
+
+        std::vector<Qot_Common::SubType> subs;
+        mask_to_vec(mask, subs);
+
+        for (auto st : subs) {
+            auto topic = runtime::topic_for_subtype(st);
+            if (topic.empty()) continue;
+
+            if (warmup_mode(topic) == cfg::WarmupMode::Bypass) {
+                continue;
+            }
+
+            auto& slot = warmups[warm_key(std::string(topic), key)];
             slot.until = until;
             slot.active = true;
             slot.buf.clear();
             slot.buf.reserve(64);
+
+            // ensure topic exists in map
+            topic_enabled[std::string(topic)] = false;
+
             logger::info("subman", "init_push_warmup_opened",
-             {logger::field("topic", t),
+             {logger::field("topic", std::string(topic)),
               logger::field("key", key),
               logger::num("warmup_ms", WARMUP.count())});
         }
@@ -217,7 +234,10 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
             slot.active = false;
             return;
         }
-        if (slot.buf.size() <= 1) {
+
+        const bool enabled = topic_enabled[std::string(topic)];
+
+        if (!enabled && slot.buf.size() <= 1) {
             // snapshot-only warmup: drop
             logger::info("subman", "init_push_drop",
             {logger::field("topic", topic),
@@ -236,6 +256,25 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
         }
         slot.buf.clear();
         slot.active = false;
+    };
+
+    // Best-effort sweep: flush/drop expired warmup buffers even if no new message arrives.
+    auto sweep_expired = [&]() {
+        if (warmups.empty() || WARMUP.count() == 0) return;
+        const auto now = std::chrono::steady_clock::now();
+        for (auto it = warmups.begin(); it != warmups.end(); ) {
+            auto& slot = it->second;
+            if (slot.active && now >= slot.until) {
+                // decode warm_key to topic/key for logging: "topic|key"
+                auto sep = it->first.find('|');
+                std::string_view topic = (sep == std::string::npos) ? std::string_view{} : std::string_view(it->first).substr(0, sep);
+                std::string_view key   = (sep == std::string::npos) ? std::string_view(it->first) : std::string_view(it->first).substr(sep + 1);
+                flush_slot(slot, topic, key);
+                it = warmups.erase(it);
+                continue;
+            }
+            ++it;
+        }
     };
 
     while (!stop.load(std::memory_order_relaxed)) {
@@ -277,8 +316,7 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
                 // "cached snapshot" push after restart from polluting downstream.
                 if (has_current_) {
                     for (const auto& [id, mask] : current_state_) {
-                        (void)mask;
-                        open_warmup_all_topics(make_key(static_cast<int>(id.market), id.code));
+                        open_warmup_for_mask(make_key(static_cast<int>(id.market), id.code), mask);
                     }
                 }
             }
@@ -303,21 +341,41 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
         }
 
         if (sink_.submit) {
+            // Flush/drop expired warmup buffers even if no new messages arrive.
+            sweep_expired();
+
             const auto now = std::chrono::steady_clock::now();
             for (auto& e : batch) {
-                auto it = warmups.find(warm_key(e.topic, e.key));
+                // Policy: bypass topics never enter warmup gate.
+                if (warmup_mode(runtime::topic_for_msgkind(e.kind)) == cfg::WarmupMode::Bypass || WARMUP.count() == 0) {
+                    sink_.submit(sink_.ctx, std::move(e));
+                    continue;
+                }
+
+                const auto wk = warm_key(std::string(runtime::topic_for_msgkind(e.kind)), e.symbol);
+                auto it = warmups.find(wk);
+
                 if (it != warmups.end() && it->second.active) {
                     auto& slot = it->second;
                     if (now < slot.until) {
                         slot.buf.emplace_back(std::move(e));
+
+                        // Topic-level enable: once any key has >= enable_threshold messages buffered,
+                        // mark this topic enabled so that single buffered messages for other keys
+                        // will be flushed (avoid false drops for low-rate symbols).
+                        if (slot.buf.size() >= opts_.warmup.enable_threshold) {
+                            topic_enabled[std::string(runtime::topic_for_msgkind(slot.buf.back().kind))] = true;
+                        }
+
                         logger::debug("subman", "init_push_buffering",
-                            {logger::field("topic", slot.buf.back().topic),
-                                logger::field("key", slot.buf.back().key),
+                            {logger::field("topic", runtime::topic_for_msgkind(slot.buf.back().kind)),
+                                logger::field("key", slot.buf.back().symbol),
                                 logger::num("buffered", slot.buf.size())});
                         continue;
                     }
-                    // window ended: flush once, then fallthrough to forward current msg
-                    flush_slot(slot, e.topic, e.key);
+                    // window ended: flush buffered once, then fallthrough to forward current msg
+                    flush_slot(slot, runtime::topic_for_msgkind(e.kind), e.symbol);
+                    warmups.erase(it);
                 }
                 sink_.submit(sink_.ctx, std::move(e));
             }
@@ -540,8 +598,8 @@ bool SubscriptionManager::enqueue(Envelope&& e) {
         return true;
     }
     if (opts_.overflow == queue::OverflowPolicy::DropOldest) {
-        const auto topic = e.topic;
-        const auto key = e.key;
+        const auto topic = runtime::topic_for_msgkind(e.kind);
+        const auto key = e.symbol;
         Envelope dropped;
         (void)inbox_.try_pop(dropped);
         logger::warn("subman", "inbox_drop_oldest",

--- a/momo_feed/src/futu_quote/SubscriptionManager.cpp
+++ b/momo_feed/src/futu_quote/SubscriptionManager.cpp
@@ -204,10 +204,14 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
             slot.active = true;
             slot.buf.clear();
             slot.buf.reserve(64);
+            logger::info("subman", "init_push_warmup_opened",
+             {logger::field("topic", t),
+              logger::field("key", key),
+              logger::num("warmup_ms", WARMUP.count())});
         }
     };
 
-    auto flush_slot = [&](WarmupSlot& slot) {
+    auto flush_slot = [&](WarmupSlot& slot, std::string_view topic, std::string_view key) {
         if (!sink_.submit) {
             slot.buf.clear();
             slot.active = false;
@@ -215,10 +219,18 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
         }
         if (slot.buf.size() <= 1) {
             // snapshot-only warmup: drop
+            logger::info("subman", "init_push_drop",
+            {logger::field("topic", topic),
+                logger::field("key", key),
+                logger::num("buffered", slot.buf.size())});
             slot.buf.clear();
             slot.active = false;
             return;
         }
+        logger::info("subman", "init_push_flush",
+             {logger::field("topic", topic),
+              logger::field("key", key),
+              logger::num("buffered", slot.buf.size())});
         for (auto& e : slot.buf) {
             sink_.submit(sink_.ctx, std::move(e));
         }
@@ -298,10 +310,14 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
                     auto& slot = it->second;
                     if (now < slot.until) {
                         slot.buf.emplace_back(std::move(e));
+                        logger::debug("subman", "init_push_buffering",
+                            {logger::field("topic", slot.buf.back().topic),
+                                logger::field("key", slot.buf.back().key),
+                                logger::num("buffered", slot.buf.size())});
                         continue;
                     }
                     // window ended: flush once, then fallthrough to forward current msg
-                    flush_slot(slot);
+                    flush_slot(slot, e.topic, e.key);
                 }
                 sink_.submit(sink_.ctx, std::move(e));
             }
@@ -510,7 +526,7 @@ Futu::u32_t SubscriptionManager::unsubscribe_api(const SecurityId& id, const std
     logger::info("subman", "unsubscribe_sent",
                  {logger::num("serial", sn),
                   logger::field("code", id.code),
-                  logger::num("subtyps", subs.size())});
+                  logger::num("subtypes", subs.size())});
     return sn;
 }
 
@@ -524,8 +540,13 @@ bool SubscriptionManager::enqueue(Envelope&& e) {
         return true;
     }
     if (opts_.overflow == queue::OverflowPolicy::DropOldest) {
+        const auto topic = e.topic;
+        const auto key = e.key;
         Envelope dropped;
         (void)inbox_.try_pop(dropped);
+        logger::warn("subman", "inbox_drop_oldest",
+             {logger::field("topic", topic),
+              logger::field("key", key)});
         return inbox_.try_push(std::move(e));
     }
     while (!inbox_.try_push(std::move(e))) {

--- a/momo_feed/src/futu_quote/SubscriptionManager.cpp
+++ b/momo_feed/src/futu_quote/SubscriptionManager.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 
 #include "common/JsonLogger.hpp"
@@ -44,14 +45,124 @@ static std::string make_key(int market, const std::string& code) {
     return market_prefix(market) + "." + code;
 }
 
-static inline std::string warm_key(const std::string& topic, const std::string& key) {
+static inline std::string warm_key_kind(MsgKind kind, const std::string& sym) {
     std::string k;
-    k.reserve(topic.size() + 1 + key.size());
-    k.append(topic);
+    auto kid = std::to_string(static_cast<int>(kind));
+    k.reserve(kid.size() + 1 + sym.size());
+    k.append(kid);
     k.push_back('|');
-    k.append(key);
+    k.append(sym);
     return k;
 }
+
+namespace {
+
+using WarmupMap = std::unordered_map<std::string, SubscriptionManager::WarmupSlot>; // "kind|sym"
+using KindEnableMap = std::unordered_map<int, bool>; // kind(int) -> enabled
+
+static cfg::WarmupMode resolve_warmup_mode(const cfg::WarmupPolicy& warmup, std::string_view topic) {
+    return warmup.mode(runtime::msgkind_for_topic(topic));
+}
+
+static void open_warmup_for_mask(
+    WarmupMap& warmups,
+    KindEnableMap& enabled,
+    const cfg::WarmupPolicy& policy,
+    std::chrono::milliseconds window,
+    const std::string& sym,
+    SubMask mask)
+{
+    if (window.count() == 0) return;
+
+    const auto until = std::chrono::steady_clock::now() + window;
+    std::vector<Qot_Common::SubType> subs;
+    mask_to_vec(mask, subs);
+
+    for (auto st : subs) {
+        auto kind = runtime::msgkind_for_subtype(st);
+        if (policy.mode(kind) == cfg::WarmupMode::Bypass) continue;
+
+        auto& slot = warmups[warm_key_kind(kind, sym)];
+        slot.until = until;
+        slot.active = true;
+        slot.buf.clear();
+        slot.buf.reserve(64);
+
+        enabled[static_cast<int>(kind)] = false;
+
+        logger::info("subman", "init_push_warmup_opened",
+            { logger::field("kind", std::to_string(static_cast<int>(kind))),
+              logger::field("topic", runtime::topic_for_msgkind(kind)),
+              logger::field("key", sym),
+              logger::num("warmup_ms", window.count())});
+    }
+}
+
+static void flush_slot(
+    Sink sink,
+    TopicEnableMap& topic_enabled,
+    SubscriptionManager::WarmupSlot& slot,
+    std::string_view topic,
+    std::string_view key) {
+    if (!sink.submit) {
+        slot.buf.clear();
+        slot.active = false;
+        return;
+    }
+
+    const bool enabled = topic_enabled[std::string(topic)];
+    if (!enabled && slot.buf.size() <= 1) {
+        const auto buffered = slot.buf.size();
+        // snapshot-only / no-push warmup: drop and raise warning for visibility.
+        logger::warn("subman", "init_push_drop",
+            {logger::field("topic", topic),
+                logger::field("key", key),
+                logger::b("no_msg", buffered == 0),
+                logger::b("single_only", buffered == 1)});
+        slot.buf.clear();
+        slot.active = false;
+        return;
+    }
+
+    logger::info("subman", "init_push_flush",
+         {logger::field("topic", topic),
+          logger::field("key", key),
+          logger::num("buffered", slot.buf.size())});
+    for (auto& e : slot.buf) {
+        sink.submit(sink.ctx, std::move(e));
+    }
+    slot.buf.clear();
+    slot.active = false;
+}
+
+static void sweep_expired_warmups(
+    WarmupMap& warmups,
+    TopicEnableMap& topic_enabled,
+    Sink sink,
+    const std::chrono::milliseconds window) {
+    if (warmups.empty() || window.count() == 0) return;
+
+    const auto now = std::chrono::steady_clock::now();
+    for (auto it = warmups.begin(); it != warmups.end(); ) {
+        auto& slot = it->second;
+        if (slot.active && now >= slot.until) {
+            const auto sep = it->first.find('|');
+            const std::string_view topic = (sep == std::string::npos)
+                ? std::string_view{}
+                : std::string_view(it->first).substr(0, sep);
+            const std::string_view key = (sep == std::string::npos)
+                ? std::string_view(it->first)
+                : std::string_view(it->first).substr(sep + 1);
+
+            flush_slot(sink, topic_enabled, slot, topic, key);
+            it = warmups.erase(it);
+            continue;
+        }
+        ++it;
+    }
+}
+
+} // namespace
 
 SubscriptionManager::SubscriptionManager(Sink sink, SubscriptionLoadFn cfgloader, Options opts)
     : sink_(sink)
@@ -184,98 +295,9 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
     std::vector<Envelope> batch;
     batch.reserve(1024);
 
-    // Per (topic|key) warmup slots.
-    std::unordered_map<std::string, WarmupSlot> warmups;
-
-    // Topic-level enable: once we observe any (topic,security) producing >= enable_threshold
-    // messages during warmup, we consider this topic "active" and will flush even single buffered
-    // messages for all securities of this topic (avoid false drops for low-rate symbols).
-    std::unordered_map<std::string, bool> topic_enabled;
-    const auto WARMUP = std::chrono::milliseconds(opts_.warmup.window_ms);
-
-    auto warmup_mode = [&](std::string_view topic) -> cfg::WarmupMode {
-        return opts_.warmup.mode(topic);
-    };
-
-    auto open_warmup_for_mask = [&](const std::string& key, SubMask mask) {
-        if (WARMUP.count() == 0) return; // disabled
-        const auto until = std::chrono::steady_clock::now() + WARMUP;
-
-        std::vector<Qot_Common::SubType> subs;
-        mask_to_vec(mask, subs);
-
-        for (auto st : subs) {
-            auto topic = runtime::topic_for_subtype(st);
-            if (topic.empty()) continue;
-
-            if (warmup_mode(topic) == cfg::WarmupMode::Bypass) {
-                continue;
-            }
-
-            auto& slot = warmups[warm_key(std::string(topic), key)];
-            slot.until = until;
-            slot.active = true;
-            slot.buf.clear();
-            slot.buf.reserve(64);
-
-            // ensure topic exists in map
-            topic_enabled[std::string(topic)] = false;
-
-            logger::info("subman", "init_push_warmup_opened",
-             {logger::field("topic", std::string(topic)),
-              logger::field("key", key),
-              logger::num("warmup_ms", WARMUP.count())});
-        }
-    };
-
-    auto flush_slot = [&](WarmupSlot& slot, std::string_view topic, std::string_view key) {
-        if (!sink_.submit) {
-            slot.buf.clear();
-            slot.active = false;
-            return;
-        }
-
-        const bool enabled = topic_enabled[std::string(topic)];
-
-        if (!enabled && slot.buf.size() <= 1) {
-            // snapshot-only warmup: drop
-            logger::info("subman", "init_push_drop",
-            {logger::field("topic", topic),
-                logger::field("key", key),
-                logger::num("buffered", slot.buf.size())});
-            slot.buf.clear();
-            slot.active = false;
-            return;
-        }
-        logger::info("subman", "init_push_flush",
-             {logger::field("topic", topic),
-              logger::field("key", key),
-              logger::num("buffered", slot.buf.size())});
-        for (auto& e : slot.buf) {
-            sink_.submit(sink_.ctx, std::move(e));
-        }
-        slot.buf.clear();
-        slot.active = false;
-    };
-
-    // Best-effort sweep: flush/drop expired warmup buffers even if no new message arrives.
-    auto sweep_expired = [&]() {
-        if (warmups.empty() || WARMUP.count() == 0) return;
-        const auto now = std::chrono::steady_clock::now();
-        for (auto it = warmups.begin(); it != warmups.end(); ) {
-            auto& slot = it->second;
-            if (slot.active && now >= slot.until) {
-                // decode warm_key to topic/key for logging: "topic|key"
-                auto sep = it->first.find('|');
-                std::string_view topic = (sep == std::string::npos) ? std::string_view{} : std::string_view(it->first).substr(0, sep);
-                std::string_view key   = (sep == std::string::npos) ? std::string_view(it->first) : std::string_view(it->first).substr(sep + 1);
-                flush_slot(slot, topic, key);
-                it = warmups.erase(it);
-                continue;
-            }
-            ++it;
-        }
-    };
+    WarmupMap warmups;
+    TopicEnableMap topic_enabled;
+    const auto warmup_window = std::chrono::milliseconds(opts_.warmup.window_ms);
 
     while (!stop.load(std::memory_order_relaxed)) {
         if (session_) {
@@ -316,7 +338,13 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
                 // "cached snapshot" push after restart from polluting downstream.
                 if (has_current_) {
                     for (const auto& [id, mask] : current_state_) {
-                        open_warmup_for_mask(make_key(static_cast<int>(id.market), id.code), mask);
+                        open_warmup_for_mask(
+                            warmups,
+                            topic_enabled,
+                            opts_.warmup,
+                            warmup_window,
+                            make_key(static_cast<int>(id.market), id.code),
+                            mask);
                     }
                 }
             }
@@ -332,6 +360,8 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
         }
 
         // --------- data plane (push -> sink) ----------
+        sweep_expired_warmups(warmups, topic_enabled, sink_, warmup_window);
+
         batch.clear();
         auto n = inbox_.pop_many(batch, 1024);
 
@@ -341,13 +371,13 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
         }
 
         if (sink_.submit) {
-            // Flush/drop expired warmup buffers even if no new messages arrive.
-            sweep_expired();
 
             const auto now = std::chrono::steady_clock::now();
             for (auto& e : batch) {
                 // Policy: bypass topics never enter warmup gate.
-                if (warmup_mode(runtime::topic_for_msgkind(e.kind)) == cfg::WarmupMode::Bypass || WARMUP.count() == 0) {
+                if (resolve_warmup_mode(opts_.warmup, runtime::topic_for_msgkind(e.kind)) == cfg::WarmupMode::Bypass
+                    || warmup_window.count() == 0)
+                {
                     sink_.submit(sink_.ctx, std::move(e));
                     continue;
                 }
@@ -374,7 +404,7 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
                         continue;
                     }
                     // window ended: flush buffered once, then fallthrough to forward current msg
-                    flush_slot(slot, runtime::topic_for_msgkind(e.kind), e.symbol);
+                    flush_slot(sink_, topic_enabled, slot, runtime::topic_for_msgkind(e.kind), e.symbol);
                     warmups.erase(it);
                 }
                 sink_.submit(sink_.ctx, std::move(e));

--- a/momo_feed/src/futu_quote/SubscriptionManager.cpp
+++ b/momo_feed/src/futu_quote/SubscriptionManager.cpp
@@ -43,6 +43,15 @@ static std::string make_key(int market, const std::string& code) {
     return market_prefix(market) + "." + code;
 }
 
+static inline std::string warm_key(const std::string& topic, const std::string& key) {
+    std::string k;
+    k.reserve(topic.size() + 1 + key.size());
+    k.append(topic);
+    k.push_back('|');
+    k.append(key);
+    return k;
+}
+
 SubscriptionManager::SubscriptionManager(Sink sink, SubscriptionLoadFn cfgloader, Options opts)
     : sink_(sink)
     , inbox_(next_pow2(opts.capacity))
@@ -85,14 +94,13 @@ void SubscriptionManager::on_push_basicqot(const Qot_UpdateBasicQot::Response &s
         Qot_UpdateBasicQot::Response single_rsp;
         single_rsp.set_rettype(stRsp.rettype());
         single_rsp.set_retmsg(stRsp.retmsg());
-        single_rsp.mutable_s2c()->CopyFrom(stRsp.s2c());
-        single_rsp.mutable_s2c()->clear_basicqotlist();
+
         single_rsp.mutable_s2c()->add_basicqotlist()->CopyFrom(item);
 
         Envelope e;
         e.topic = "futu.basicqot.pb";
         e.key = make_key(sec.market(), sec.code());
-        e.ts_ns = now_ns();
+        e.ingest_time_ms = now_ms();
         e.payload.resize(static_cast<size_t>(single_rsp.ByteSizeLong()));
         if (!single_rsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
             continue;
@@ -106,7 +114,7 @@ void SubscriptionManager::on_push_orderbook(const Qot_UpdateOrderBook::Response 
     e.topic = "futu.orderbook.pb";
     const auto& sec = stRsp.s2c().security();
     e.key = make_key(sec.market(), sec.code());
-    e.ts_ns = now_ns();
+    e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
         return;
@@ -120,7 +128,7 @@ void SubscriptionManager::on_push_ticker(const Qot_UpdateTicker::Response &stRsp
     e.topic = "futu.ticker.pb";
     const auto& sec = stRsp.s2c().security();
     e.key = make_key(sec.market(), sec.code());
-    e.ts_ns = now_ns();
+    e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
         return;
@@ -134,7 +142,7 @@ void SubscriptionManager::on_push_kl(const Qot_UpdateKL::Response &stRsp)
     e.topic = "futu.kl1min.pb";
     const auto& sec = stRsp.s2c().security();
     e.key = make_key(sec.market(), sec.code());
-    e.ts_ns = now_ns();
+    e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
         return;
@@ -148,7 +156,7 @@ void SubscriptionManager::on_push_rt(const Qot_UpdateRT::Response &stRsp)
     e.topic = "futu.rt.pb";
     const auto& sec = stRsp.s2c().security();
     e.key = make_key(sec.market(), sec.code());
-    e.ts_ns = now_ns();
+    e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
         return;
@@ -162,7 +170,7 @@ void SubscriptionManager::on_push_broker(const Qot_UpdateBroker::Response &stRsp
     e.topic = "futu.broker.pb";
     const auto& sec = stRsp.s2c().security();
     e.key = make_key(sec.market(), sec.code());
-    e.ts_ns = now_ns();
+    e.ingest_time_ms = now_ms();
     e.payload.resize(static_cast<size_t>(stRsp.ByteSizeLong()));
     if (!stRsp.SerializeToArray(e.payload.data(), static_cast<int>(e.payload.size()))) {
         return;
@@ -174,6 +182,49 @@ void SubscriptionManager::on_push_broker(const Qot_UpdateBroker::Response &stRsp
 void SubscriptionManager::run(std::atomic<bool> &stop) {
     std::vector<Envelope> batch;
     batch.reserve(1024);
+
+    // Per (topic|key) warmup slots.
+    std::unordered_map<std::string, WarmupSlot> warmups;
+    constexpr auto WARMUP = std::chrono::milliseconds(1000);
+
+    auto open_warmup_all_topics = [&](const std::string& key) {
+        const auto until = std::chrono::steady_clock::now() + WARMUP;
+        // We open warmup for all topics we produce.
+        static constexpr const char* TOPICS[] = {
+            "futu.basicqot.pb",
+            "futu.orderbook.pb",
+            "futu.ticker.pb",
+            "futu.kl1min.pb",
+            "futu.rt.pb",
+            "futu.broker.pb",
+        };
+        for (auto* t : TOPICS) {
+            auto& slot = warmups[warm_key(t, key)];
+            slot.until = until;
+            slot.active = true;
+            slot.buf.clear();
+            slot.buf.reserve(64);
+        }
+    };
+
+    auto flush_slot = [&](WarmupSlot& slot) {
+        if (!sink_.submit) {
+            slot.buf.clear();
+            slot.active = false;
+            return;
+        }
+        if (slot.buf.size() <= 1) {
+            // snapshot-only warmup: drop
+            slot.buf.clear();
+            slot.active = false;
+            return;
+        }
+        for (auto& e : slot.buf) {
+            sink_.submit(sink_.ctx, std::move(e));
+        }
+        slot.buf.clear();
+        slot.active = false;
+    };
 
     while (!stop.load(std::memory_order_relaxed)) {
         if (session_) {
@@ -208,6 +259,16 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
             // 3) If we have pending, apply it (diff or full)
             if (has_pending_) {
                 apply_pending();
+
+                // After (re)apply subscriptions, open a short warmup window for
+                // all currently subscribed securities. This prevents a single
+                // "cached snapshot" push after restart from polluting downstream.
+                if (has_current_) {
+                    for (const auto& [id, mask] : current_state_) {
+                        (void)mask;
+                        open_warmup_all_topics(make_key(static_cast<int>(id.market), id.code));
+                    }
+                }
             }
 
             // 4) Only clear force after we've at least attempted a connected-cycle load.
@@ -230,7 +291,18 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
         }
 
         if (sink_.submit) {
+            const auto now = std::chrono::steady_clock::now();
             for (auto& e : batch) {
+                auto it = warmups.find(warm_key(e.topic, e.key));
+                if (it != warmups.end() && it->second.active) {
+                    auto& slot = it->second;
+                    if (now < slot.until) {
+                        slot.buf.emplace_back(std::move(e));
+                        continue;
+                    }
+                    // window ended: flush once, then fallthrough to forward current msg
+                    flush_slot(slot);
+                }
                 sink_.submit(sink_.ctx, std::move(e));
             }
         }
@@ -442,9 +514,9 @@ Futu::u32_t SubscriptionManager::unsubscribe_api(const SecurityId& id, const std
     return sn;
 }
 
-int64_t SubscriptionManager::now_ns() {
+int64_t SubscriptionManager::now_ms() {
     using namespace std::chrono;
-    return duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count();
+    return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
 
 bool SubscriptionManager::enqueue(Envelope&& e) {

--- a/momo_feed/src/futu_quote/SubscriptionManager.cpp
+++ b/momo_feed/src/futu_quote/SubscriptionManager.cpp
@@ -57,52 +57,52 @@ static inline std::string warm_key_kind(MsgKind kind, const std::string& sym) {
 
 namespace {
 
-using WarmupMap = std::unordered_map<std::string, SubscriptionManager::WarmupSlot>; // "kind|sym"
-using KindEnableMap = std::unordered_map<int, bool>; // kind(int) -> enabled
+    using WarmupMap = std::unordered_map<std::string, SubscriptionManager::WarmupSlot>; // "kind|sym"
+    using KindEnableMap = std::unordered_map<int, bool>; // kind(int) -> enabled
 
-static cfg::WarmupMode resolve_warmup_mode(const cfg::WarmupPolicy& warmup, std::string_view topic) {
-    return warmup.mode(runtime::msgkind_for_topic(topic));
-}
-
-static void open_warmup_for_mask(
-    WarmupMap& warmups,
-    KindEnableMap& enabled,
-    const cfg::WarmupPolicy& policy,
-    std::chrono::milliseconds window,
-    const std::string& sym,
-    SubMask mask)
-{
-    if (window.count() == 0) return;
-
-    const auto until = std::chrono::steady_clock::now() + window;
-    std::vector<Qot_Common::SubType> subs;
-    mask_to_vec(mask, subs);
-
-    for (auto st : subs) {
-        auto kind = runtime::msgkind_for_subtype(st);
-        if (policy.mode(kind) == cfg::WarmupMode::Bypass) continue;
-
-        auto& slot = warmups[warm_key_kind(kind, sym)];
-        slot.until = until;
-        slot.active = true;
-        slot.buf.clear();
-        slot.buf.reserve(64);
-
-        enabled[static_cast<int>(kind)] = false;
-
-        logger::info("subman", "init_push_warmup_opened",
-            { logger::field("kind", std::to_string(static_cast<int>(kind))),
-              logger::field("topic", runtime::topic_for_msgkind(kind)),
-              logger::field("key", sym),
-              logger::num("warmup_ms", window.count())});
+    static cfg::WarmupMode resolve_warmup_mode(const cfg::WarmupPolicy& warmup, MsgKind kind) {
+        return warmup.mode(kind);
     }
-}
+
+    static void open_warmup_for_mask(
+        WarmupMap& warmups,
+        KindEnableMap& enabled,
+        const cfg::WarmupPolicy& policy,
+        std::chrono::milliseconds window,
+        const std::string& sym,
+        SubMask mask)
+    {
+        if (window.count() == 0) return;
+
+        const auto until = std::chrono::steady_clock::now() + window;
+        std::vector<Qot_Common::SubType> subs;
+        mask_to_vec(mask, subs);
+
+        for (auto st : subs) {
+            auto kind = runtime::msgkind_for_subtype(st);
+            if (policy.mode(kind) == cfg::WarmupMode::Bypass) continue;
+
+            auto& slot = warmups[warm_key_kind(kind, sym)];
+            slot.until = until;
+            slot.active = true;
+            slot.buf.clear();
+            slot.buf.reserve(64);
+
+            enabled[static_cast<int>(kind)] = false;
+
+            logger::info("subman", "init_push_warmup_opened",
+                { logger::field("kind", std::to_string(static_cast<int>(kind))),
+                  logger::field("topic", runtime::topic_for_msgkind(kind)),
+                  logger::field("key", sym),
+                  logger::num("warmup_ms", window.count())});
+        }
+    }
 
 static void flush_slot(
     Sink sink,
-    TopicEnableMap& topic_enabled,
+    KindEnableMap& kind_enabled,
     SubscriptionManager::WarmupSlot& slot,
-    std::string_view topic,
+    MsgKind kind,
     std::string_view key) {
     if (!sink.submit) {
         slot.buf.clear();
@@ -110,12 +110,12 @@ static void flush_slot(
         return;
     }
 
-    const bool enabled = topic_enabled[std::string(topic)];
+    const bool enabled = kind_enabled[static_cast<int>(kind)];
     if (!enabled && slot.buf.size() <= 1) {
         const auto buffered = slot.buf.size();
         // snapshot-only / no-push warmup: drop and raise warning for visibility.
         logger::warn("subman", "init_push_drop",
-            {logger::field("topic", topic),
+            {logger::field("topic", runtime::topic_for_msgkind(kind)),
                 logger::field("key", key),
                 logger::b("no_msg", buffered == 0),
                 logger::b("single_only", buffered == 1)});
@@ -125,7 +125,7 @@ static void flush_slot(
     }
 
     logger::info("subman", "init_push_flush",
-         {logger::field("topic", topic),
+        {logger::field("topic", runtime::topic_for_msgkind(kind)),
           logger::field("key", key),
           logger::num("buffered", slot.buf.size())});
     for (auto& e : slot.buf) {
@@ -137,7 +137,7 @@ static void flush_slot(
 
 static void sweep_expired_warmups(
     WarmupMap& warmups,
-    TopicEnableMap& topic_enabled,
+    KindEnableMap& kind_enabled,
     Sink sink,
     const std::chrono::milliseconds window) {
     if (warmups.empty() || window.count() == 0) return;
@@ -147,14 +147,19 @@ static void sweep_expired_warmups(
         auto& slot = it->second;
         if (slot.active && now >= slot.until) {
             const auto sep = it->first.find('|');
-            const std::string_view topic = (sep == std::string::npos)
+            const std::string_view kind_sv = (sep == std::string::npos)
                 ? std::string_view{}
                 : std::string_view(it->first).substr(0, sep);
             const std::string_view key = (sep == std::string::npos)
                 ? std::string_view(it->first)
                 : std::string_view(it->first).substr(sep + 1);
 
-            flush_slot(sink, topic_enabled, slot, topic, key);
+            MsgKind kind = MsgKind::BasicQuote;
+            if (!kind_sv.empty()) {
+                kind = static_cast<MsgKind>(std::stoi(std::string(kind_sv)));
+            }
+
+            flush_slot(sink, kind_enabled, slot, kind, key);
             it = warmups.erase(it);
             continue;
         }
@@ -296,7 +301,7 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
     batch.reserve(1024);
 
     WarmupMap warmups;
-    TopicEnableMap topic_enabled;
+    KindEnableMap kind_enabled;
     const auto warmup_window = std::chrono::milliseconds(opts_.warmup.window_ms);
 
     while (!stop.load(std::memory_order_relaxed)) {
@@ -340,7 +345,7 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
                     for (const auto& [id, mask] : current_state_) {
                         open_warmup_for_mask(
                             warmups,
-                            topic_enabled,
+                            kind_enabled,
                             opts_.warmup,
                             warmup_window,
                             make_key(static_cast<int>(id.market), id.code),
@@ -360,7 +365,7 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
         }
 
         // --------- data plane (push -> sink) ----------
-        sweep_expired_warmups(warmups, topic_enabled, sink_, warmup_window);
+        sweep_expired_warmups(warmups, kind_enabled, sink_, warmup_window);
 
         batch.clear();
         auto n = inbox_.pop_many(batch, 1024);
@@ -375,14 +380,14 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
             const auto now = std::chrono::steady_clock::now();
             for (auto& e : batch) {
                 // Policy: bypass topics never enter warmup gate.
-                if (resolve_warmup_mode(opts_.warmup, runtime::topic_for_msgkind(e.kind)) == cfg::WarmupMode::Bypass
+                if (resolve_warmup_mode(opts_.warmup, e.kind) == cfg::WarmupMode::Bypass
                     || warmup_window.count() == 0)
                 {
                     sink_.submit(sink_.ctx, std::move(e));
                     continue;
                 }
 
-                const auto wk = warm_key(std::string(runtime::topic_for_msgkind(e.kind)), e.symbol);
+                const auto wk = warm_key_kind(e.kind, e.symbol);
                 auto it = warmups.find(wk);
 
                 if (it != warmups.end() && it->second.active) {
@@ -394,7 +399,7 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
                         // mark this topic enabled so that single buffered messages for other keys
                         // will be flushed (avoid false drops for low-rate symbols).
                         if (slot.buf.size() >= opts_.warmup.enable_threshold) {
-                            topic_enabled[std::string(runtime::topic_for_msgkind(slot.buf.back().kind))] = true;
+                            kind_enabled[static_cast<int>(slot.buf.back().kind)] = true;
                         }
 
                         logger::debug("subman", "init_push_buffering",
@@ -404,7 +409,7 @@ void SubscriptionManager::run(std::atomic<bool> &stop) {
                         continue;
                     }
                     // window ended: flush buffered once, then fallthrough to forward current msg
-                    flush_slot(sink_, topic_enabled, slot, runtime::topic_for_msgkind(e.kind), e.symbol);
+                    flush_slot(sink_, kind_enabled, slot, e.kind, e.symbol);
                     warmups.erase(it);
                 }
                 sink_.submit(sink_.ctx, std::move(e));

--- a/momo_feed/src/main.cpp
+++ b/momo_feed/src/main.cpp
@@ -88,7 +88,7 @@ int main (int argc, char *argv[]) {
                 wp.window_ms = cfg.submanager.warmup.window_ms;
                 wp.enable_threshold = cfg.submanager.warmup.enable_threshold;
                 // default: bypass list from config (can be empty)
-                for (const auto& t : cfg.submanager.warmup.bypass_topics) wp.bypass_topics.insert(t);
+                for (const auto& t : cfg.submanager.warmup.bypass_topics) wp.bypass_kinds.insert(t);
                 return wp;
             }()
         });

--- a/momo_feed/src/main.cpp
+++ b/momo_feed/src/main.cpp
@@ -88,7 +88,9 @@ int main (int argc, char *argv[]) {
                 wp.window_ms = cfg.submanager.warmup.window_ms;
                 wp.enable_threshold = cfg.submanager.warmup.enable_threshold;
                 // default: bypass list from config (can be empty)
-                for (const auto& t : cfg.submanager.warmup.bypass_topics) wp.bypass_kinds.insert(t);
+                for (int k : cfg.submanager.warmup.bypass_kinds) {
+                    wp.bypass_kinds.insert(k);
+                }
                 return wp;
             }()
         });

--- a/momo_feed/src/main.cpp
+++ b/momo_feed/src/main.cpp
@@ -88,7 +88,7 @@ int main (int argc, char *argv[]) {
                 wp.window_ms = cfg.submanager.warmup.window_ms;
                 wp.enable_threshold = cfg.submanager.warmup.enable_threshold;
                 // default: bypass list from config (can be empty)
-                for (int k : cfg.submanager.warmup.bypass_kinds) {
+                for (auto k : cfg.submanager.warmup.bypass_kinds) {
                     wp.bypass_kinds.insert(k);
                 }
                 return wp;

--- a/momo_feed/src/main.cpp
+++ b/momo_feed/src/main.cpp
@@ -82,7 +82,15 @@ int main (int argc, char *argv[]) {
             cfg.subscription.path,
             std::chrono::milliseconds{cfg.submanager.refresh_ms},
             cfg.submanager.capacity,
-            to_queue_overflow(cfg.submanager.overflow)
+            to_queue_overflow(cfg.submanager.overflow),
+            [&](){
+                cfg::WarmupPolicy wp;
+                wp.window_ms = cfg.submanager.warmup.window_ms;
+                wp.enable_threshold = cfg.submanager.warmup.enable_threshold;
+                // default: bypass list from config (can be empty)
+                for (const auto& t : cfg.submanager.warmup.bypass_topics) wp.bypass_topics.insert(t);
+                return wp;
+            }()
         });
    
     SessionCallbacks cbs;

--- a/momo_feed/src/runtime/TopicRegistry.cpp
+++ b/momo_feed/src/runtime/TopicRegistry.cpp
@@ -1,0 +1,30 @@
+#include "runtime/TopicRegistry.hpp"
+
+namespace runtime {
+
+    std::string_view topic_for_msgkind(MsgKind kind) noexcept {
+        switch (kind) {
+            case MsgKind::BasicQuote:   return "futu.basicqot.pb";
+            case MsgKind::OrderBook:    return "futu.orderbook.pb";
+            case MsgKind::Ticker:       return "futu.ticker.pb";
+            case MsgKind::KL1Min:       return "futu.kl1min.pb";
+            case MsgKind::RT:           return "futu.rt.pb";
+            case MsgKind::Broker:       return "futu.broker.pb";
+            default:                    return {};
+        }
+    }
+
+    std::string_view topic_for_subtype(Qot_Common::SubType st) noexcept {
+        using ST = Qot_Common::SubType;
+        switch (st) {
+            case ST::SubType_Basic:     return "futu.basicqot.pb";
+            case ST::SubType_OrderBook: return "futu.orderbook.pb";
+            case ST::SubType_Ticker:    return "futu.ticker.pb";
+            case ST::SubType_KL_1Min:   return "futu.kl1min.pb";
+            case ST::SubType_RT:        return "futu.rt.pb";
+            case ST::SubType_Broker:    return "futu.broker.pb";
+            default:                    return {};
+        }
+    }
+
+} // namespace runtime

--- a/momo_feed/src/runtime/TopicRegistry.cpp
+++ b/momo_feed/src/runtime/TopicRegistry.cpp
@@ -27,4 +27,27 @@ namespace runtime {
         }
     }
 
+    MsgKind msgkind_for_topic(std::string_view tp) noexcept {
+        if (tp == "futu.basicqot.pb") return MsgKind::BasicQuote;
+        if (tp == "futu.orderbook.pb") return MsgKind::OrderBook;
+        if (tp == "futu.ticker.pb") return MsgKind::Ticker;
+        if (tp == "futu.kl1min.pb") return MsgKind::KL1Min;
+        if (tp == "futu.rt.pb") return MsgKind::RT;
+        if (tp == "futu.broker.pb") return MsgKind::Broker;
+        return MsgKind::BasicQuote;
+    }
+
+    MsgKind msgkind_for_subtype(Qot_Common::SubType st) noexcept {
+        using ST = Qot_Common::SubType;
+        switch (st) {
+            case ST::SubType_Basic:     return MsgKind::BasicQuote;
+            case ST::SubType_OrderBook: return MsgKind::OrderBook;
+            case ST::SubType_Ticker:    return MsgKind::Ticker;
+            case ST::SubType_KL_1Min:   return MsgKind::KL1Min;
+            case ST::SubType_RT:        return MsgKind::RT;
+            case ST::SubType_Broker:    return MsgKind::Broker;
+            default:                    return MsgKind::BasicQuote;
+        }
+    }
+
 } // namespace runtime

--- a/momo_feed/src/runtime/TopicRegistry.cpp
+++ b/momo_feed/src/runtime/TopicRegistry.cpp
@@ -27,14 +27,14 @@ namespace runtime {
         }
     }
 
-    MsgKind msgkind_for_topic(std::string_view tp) noexcept {
-        if (tp == "futu.basicqot.pb") return MsgKind::BasicQuote;
-        if (tp == "futu.orderbook.pb") return MsgKind::OrderBook;
-        if (tp == "futu.ticker.pb") return MsgKind::Ticker;
-        if (tp == "futu.kl1min.pb") return MsgKind::KL1Min;
-        if (tp == "futu.rt.pb") return MsgKind::RT;
-        if (tp == "futu.broker.pb") return MsgKind::Broker;
-        return MsgKind::BasicQuote;
+    MsgKind msgkind_for_yamlcfg(std::string_view tp) noexcept {
+        if (tp == "BasicQot") return MsgKind::BasicQuote;
+        if (tp == "OrderBook") return MsgKind::OrderBook;
+        if (tp == "Ticker") return MsgKind::Ticker;
+        if (tp == "KL1Min") return MsgKind::KL1Min;
+        if (tp == "RT") return MsgKind::RT;
+        if (tp == "Broker") return MsgKind::Broker;
+        return MsgKind::Unknown;
     }
 
     MsgKind msgkind_for_subtype(Qot_Common::SubType st) noexcept {

--- a/momo_feed/src/sinks/RedPandaSink.cpp
+++ b/momo_feed/src/sinks/RedPandaSink.cpp
@@ -7,6 +7,7 @@
 #include <librdkafka/rdkafka.h>
 
 #include "common/JsonLogger.hpp"
+#include "runtime/TopicRegistry.hpp"
 
 namespace {
 
@@ -76,13 +77,15 @@ void RedPandaSink::submit(std::shared_ptr<const Envelope> e) {
     if (!producer_ || !e) return;
 
     const std::int64_t timestamp_ms = e->ingest_time_ms;
+    auto sv = runtime::topic_for_msgkind(e->kind);
     const auto err = rd_kafka_producev(
         producer_,
-        RD_KAFKA_V_TOPIC(e->topic.c_str()),
+        RD_KAFKA_V_TOPIC(sv.data()),
         RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
         RD_KAFKA_V_TIMESTAMP(timestamp_ms),
-        RD_KAFKA_V_KEY(e->key.data(), e->key.size()),
-        RD_KAFKA_V_VALUE(const_cast<char*>(e->payload.data()), e->payload.size()),
+        RD_KAFKA_V_KEY(e->symbol.data(), e->symbol.size()),
+        RD_KAFKA_V_VALUE(const_cast<void*>(reinterpret_cast<const void*>(e->payload.data())),
+                 e->payload.size()),
         RD_KAFKA_V_END);
 
     if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
@@ -91,8 +94,8 @@ void RedPandaSink::submit(std::shared_ptr<const Envelope> e) {
         }
         logger::warn("sink", "redpanda_produce_failed",
                      {logger::field("name", name_),
-                      logger::field("topic", e->topic),
-                      logger::field("key", e->key),
+                      logger::field("topic", runtime::topic_for_msgkind(e->kind)),
+                      logger::field("key", e->symbol),
                       logger::field("error", rd_kafka_err2str(err))});
         return;
     }

--- a/momo_feed/src/sinks/RedPandaSink.cpp
+++ b/momo_feed/src/sinks/RedPandaSink.cpp
@@ -75,7 +75,7 @@ RedPandaSink::~RedPandaSink() {
 void RedPandaSink::submit(std::shared_ptr<const Envelope> e) {
     if (!producer_ || !e) return;
 
-    const std::int64_t timestamp_ms = to_timestamp_ms(e->ts_ns);
+    const std::int64_t timestamp_ms = e->ingest_time_ms;
     const auto err = rd_kafka_producev(
         producer_,
         RD_KAFKA_V_TOPIC(e->topic.c_str()),


### PR DESCRIPTION
Warmup Mechanism (Init Push Handling)

Purpose
Suppress redundant snapshot (init push) messages immediately after (re)subscribe.

How it works

Warmup is applied per (MsgKind, key).

When subscription starts, a window_ms timer is opened.

Messages received during the window are buffered (not forwarded).

When the window closes:

If buffer.size() >= enable_threshold → flush buffered messages (real stream active).

Otherwise → drop buffered messages (snapshot-only case).

Kinds listed in bypass_kinds skip warmup and pass through directly.

This prevents snapshot spam while preserving real early updates.

Closes #7 